### PR TITLE
Default font used in mame.ini. #8 v36 Fix

### DIFF
--- a/userdata/system/BUILD_15KHz/Mame_configs/mame.ini-switchres-generic-v36
+++ b/userdata/system/BUILD_15KHz/Mame_configs/mame.ini-switchres-generic-v36
@@ -189,7 +189,7 @@ drc_log_native            0
 bios                      
 cheat                     0
 skip_gameinfo             0
-uifont                    default
+uifont                    uismall.bdf
 ui                        cabinet
 ramsize                   
 confirm_quit              0


### PR DESCRIPTION
Fixed issue [8#issue-1431349906](https://github.com/ZFEbHVUE/Build-CRT-15KHz-Batocera-V35/issues/8#issue-1431349906) for v36