### PR TITLE
Fixed some issues

### DIFF
--- a/userdata/system/BUILD_15KHz/Batocera_ALLINONE/BUILD_15KHZ_BATOCERA.sh
+++ b/userdata/system/BUILD_15KHz/Batocera_ALLINONE/BUILD_15KHZ_BATOCERA.sh
@@ -1525,7 +1525,6 @@ echo "global.bezel=none" 						>> /userdata/system/batocera.conf
 echo "global.bezel_stretch=0" 						>> /userdata/system/batocera.conf
 echo "global.bezel.tattoo=0" 						>> /userdata/system/batocera.conf
 echo "global.hud=none" 							>> /userdata/system/batocera.conf
-echo "io=core" 								>> /userdata/system/batocera.conf
 echo "###################################################"		>> /userdata/system/batocera.conf
 #########################################################################################################
 ##  DISABLE GLOBAL NOTIFICATIONS  
@@ -1691,7 +1690,6 @@ echo "mame.bezel.tattoo=0"	>> /userdata/system/batocera.conf
 echo "mame.bgfxshaders=None"	>> /userdata/system/batocera.conf
 echo "mame.hud=none"		>> /userdata/system/batocera.conf
 echo "mame.switchres=1"		>> /userdata/system/batocera.conf
-echo "mame.video=opengl"        >> /userdata/system/batocera.conf
 
 echo "# MAME TATE MODE" >> /userdata/system/batocera.conf 
  


### PR DESCRIPTION
io=core
This has no effect and is useless. 

mame.video=opengl
This will break the new video option introduced in mame 0.246  We let Gm decide the best video driver to use.