### PR TITLE
Update BUILD_15KHZ_BATOCERA.sh

### DIFF
--- a/userdata/system/BUILD_15KHz/Batocera_ALLINONE/BUILD_15KHZ_BATOCERA.sh
+++ b/userdata/system/BUILD_15KHz/Batocera_ALLINONE/BUILD_15KHZ_BATOCERA.sh
@@ -788,7 +788,7 @@ if [ "$TYPE_OF_CARD" == "AMD/ATI" ]; then
 			if [ "$R9_380" == "YES" ]; then
 				video_modeline=$term_DVI-$((nbr))
 			else
-				video_modeline=$term_DVI-$((nbr-1))n
+				video_modeline=$term_DVI-$((nbr-1))
 			fi
 		fi  
 


### PR DESCRIPTION
video_modeline=$term_DVI-$((nbr-1))n
Just deleting that "n" from the end of the line, the script is fixed.

From FrankGB

