### PR TITLE
Update BUILD_15KHZ_BATOCERA.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ## Foreword
 
 This script would not have been possible without the following people to name a few:
- - ZFEbHVUE, main coder and tester
- - Rion
- - myzar's Nvidia knowledge
+ - ZFEbHVUE, main coder and tester.
+ - Rion.
+ - myzar's Nvidia knowledge.
  - jfroco's work to output Batocera on a CRTs.
  - rtissera's knowledge, enthusiasm and willingness to add 15 KHz patches.
  - Calamity for his knowledge, drivers, tools and GroovyMame.
@@ -12,23 +12,23 @@ This script would not have been possible without the following people to name a 
  - dmanlcf's work on keeping up to date for the 15khz patches for Batocera.
 
 
-### Tester's 
- - GecKoTDF
- - Sirmagb
+### Tester's: 
+ - GecKoTDF.
+ - Sirmagb.
 
-### Special Thanks
-- krahsdevil (Emulation Station assets) 
+### Special Thanks:
+- krahsdevil (Emulation Station assets). 
 
 ## :video_game::penguin: Build-CRT-15KHz-Batocera-V35 :video_game::penguin:
-Build-CRT-15KHz-Batocera V32 to V35 and 36-dev-2022/10/28
+Build-CRT-15KHz-Batocera V32 to V35 and V36.
 
-First public release
+First public release.
 
-This bash script will help you setup Batocera on a Crt in 15-25-31kHz
+This bash script will help you setup Batocera on a Crt in 15-25-31kHz.
 
 It comes pre-configured with the 7 most common Monitor Profiles generated with Switchres.
 
-These pre-configured Monitor Profiles have 30+ resolutions added that should only be used with
+These pre-configured Monitor Profiles have 30+ resolutions added that should only be used with:
 
     Standalone Emulators
     Native Linux Games
@@ -36,15 +36,15 @@ These pre-configured Monitor Profiles have 30+ resolutions added that should onl
     Wine, Flatpak & Steam
     For GroovyMame and Retroarch use video mode set to auto.
 
-Monitor Profile info
+Monitor Profile info:
 
-    generic_15 - Good all around profile for generic Crt's with a range between - 15625-15750 kHz
-    arcade_15 - Works well on normal consumer sets and has a wider range between - 15625-16200 kHz
-    arcade_15ex - Same as arcade_15 with a slightly higher range between - 15625-16500 kHz
-    arcade_15_25 - 15/25kHz Dual-sync arcade monitor - 15625-16200/24960-24960 kHz
-    arcade_15_25_31 - 15.7/25.0/31.5 kHz - Tri-sync arcade monitor - 15625-16200/24960-24960/31400-31500 Khz
-    ntsc - Consumer sets only capable of displaying 60Hz/525 - 15734.26-15734.26 Khz
-    pal - Consumer sets only capable of displaying 50Hz/625 - 15625.00-15625.00 Khz
+    generic_15 - Good all around profile for generic Crt's with a range between - 15625-15750 kHz.
+    arcade_15 - Works well on normal consumer sets and has a wider range between - 15625-16200 kHz.
+    arcade_15ex - Same as arcade_15 with a slightly higher range between - 15625-16500 kHz.
+    arcade_15_25 - 15/25kHz Dual-sync arcade monitor - 15625-16200/24960-24960 kHz.
+    arcade_15_25_31 - 15.7/25.0/31.5 kHz - Tri-sync arcade monitor - 15625-16200/24960-24960/31400-31500 Khz.
+    ntsc - Consumer sets only capable of displaying 60Hz/525 - 15734.26-15734.26 Khz.
+    pal - Consumer sets only capable of displaying 50Hz/625 - 15625.00-15625.00 Khz.
 
 AMD Cards are preferred.
 
@@ -52,17 +52,17 @@ AMD Cards are preferred.
 
 Intel have beentested and works somewhat.
     
-    Tested on Optilex 790 and 7010
+    Tested on Optilex 790 and 7010.
     It works with good on DisplayPort and somewhat on VGA (dotclock_min 25.0).
 
 Nvidia Cards that are supported right now.
 
-    It works for Kelper / Maxwell / Pascal with Nvidia driver (best performances) and Nouveau
+    It works for Kelper / Maxwell / Pascal with Nvidia driver (best performances) and Nouveau.
     Tested on :
-    8400GS        DVI-I / HDMI / VGA     Only Nouveau with dotclock_min 0 
-    Quadro K600   DVI-I             Nvidia driver : dotclock_min 25.0  (Good performances)     Nouveau : dotclock_min 0.0 (not so good perfomrance)
+    8400GS        DVI-I / HDMI / VGA     Only Nouveau with dotclock_min 0.
+    Quadro K600   DVI-I             Nvidia driver : dotclock_min 25.0  (Good performances)     Nouveau : dotclock_min 0.0 (not so good perfomrance).
     GTX 980       DVI-I / HMDI      DVI-I : dotclock_min 0.0        HDMI : dotclock_min 25.0   Nouveau :
-    GTX 1050ti    HDMI              dotclock_min 25.0 (very good performances)   
+    GTX 1050ti    HDMI              dotclock_min 25.0 (very good performances).
     
     Display port (DP) works for all cards but it is only for Super-resolution 240p (no interlace here).
     Turing works poorly only in 240p (tested on GTX 1650 HDMI/DP).

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ## Foreword
 
 This script would not have been possible without the following people to name a few:
- - ZFEbHVUE, main coder and tester.
- - Rion.
- - myzar's Nvidia knowledge.
+ - ZFEbHVUE, main coder and tester
+ - Rion
+ - myzar's Nvidia knowledge
  - jfroco's work to output Batocera on a CRTs.
  - rtissera's knowledge, enthusiasm and willingness to add 15 KHz patches.
  - Calamity for his knowledge, drivers, tools and GroovyMame.
@@ -12,23 +12,23 @@ This script would not have been possible without the following people to name a 
  - dmanlcf's work on keeping up to date for the 15khz patches for Batocera.
 
 
-### Tester's: 
- - GecKoTDF.
- - Sirmagb.
+### Tester's 
+ - GecKoTDF
+ - Sirmagb
 
-### Special Thanks:
-- krahsdevil (Emulation Station assets). 
+### Special Thanks
+- krahsdevil (Emulation Station assets) 
 
 ## :video_game::penguin: Build-CRT-15KHz-Batocera-V35 :video_game::penguin:
-Build-CRT-15KHz-Batocera V32 to V35 and V36.
+Build-CRT-15KHz-Batocera V32 to V35 and 36-dev-2022/10/28
 
-First public release.
+First public release
 
-This bash script will help you setup Batocera on a Crt in 15-25-31kHz.
+This bash script will help you setup Batocera on a Crt in 15-25-31kHz
 
 It comes pre-configured with the 7 most common Monitor Profiles generated with Switchres.
 
-These pre-configured Monitor Profiles have 30+ resolutions added that should only be used with:
+These pre-configured Monitor Profiles have 30+ resolutions added that should only be used with
 
     Standalone Emulators
     Native Linux Games
@@ -36,15 +36,15 @@ These pre-configured Monitor Profiles have 30+ resolutions added that should onl
     Wine, Flatpak & Steam
     For GroovyMame and Retroarch use video mode set to auto.
 
-Monitor Profile info:
+Monitor Profile info
 
-    generic_15 - Good all around profile for generic Crt's with a range between - 15625-15750 kHz.
-    arcade_15 - Works well on normal consumer sets and has a wider range between - 15625-16200 kHz.
-    arcade_15ex - Same as arcade_15 with a slightly higher range between - 15625-16500 kHz.
-    arcade_15_25 - 15/25kHz Dual-sync arcade monitor - 15625-16200/24960-24960 kHz.
-    arcade_15_25_31 - 15.7/25.0/31.5 kHz - Tri-sync arcade monitor - 15625-16200/24960-24960/31400-31500 Khz.
-    ntsc - Consumer sets only capable of displaying 60Hz/525 - 15734.26-15734.26 Khz.
-    pal - Consumer sets only capable of displaying 50Hz/625 - 15625.00-15625.00 Khz.
+    generic_15 - Good all around profile for generic Crt's with a range between - 15625-15750 kHz
+    arcade_15 - Works well on normal consumer sets and has a wider range between - 15625-16200 kHz
+    arcade_15ex - Same as arcade_15 with a slightly higher range between - 15625-16500 kHz
+    arcade_15_25 - 15/25kHz Dual-sync arcade monitor - 15625-16200/24960-24960 kHz
+    arcade_15_25_31 - 15.7/25.0/31.5 kHz - Tri-sync arcade monitor - 15625-16200/24960-24960/31400-31500 Khz
+    ntsc - Consumer sets only capable of displaying 60Hz/525 - 15734.26-15734.26 Khz
+    pal - Consumer sets only capable of displaying 50Hz/625 - 15625.00-15625.00 Khz
 
 AMD Cards are preferred.
 
@@ -52,17 +52,17 @@ AMD Cards are preferred.
 
 Intel have beentested and works somewhat.
     
-    Tested on Optilex 790 and 7010.
+    Tested on Optilex 790 and 7010
     It works with good on DisplayPort and somewhat on VGA (dotclock_min 25.0).
 
 Nvidia Cards that are supported right now.
 
-    It works for Kelper / Maxwell / Pascal with Nvidia driver (best performances) and Nouveau.
+    It works for Kelper / Maxwell / Pascal with Nvidia driver (best performances) and Nouveau
     Tested on :
-    8400GS        DVI-I / HDMI / VGA     Only Nouveau with dotclock_min 0.
-    Quadro K600   DVI-I             Nvidia driver : dotclock_min 25.0  (Good performances)     Nouveau : dotclock_min 0.0 (not so good perfomrance).
+    8400GS        DVI-I / HDMI / VGA     Only Nouveau with dotclock_min 0 
+    Quadro K600   DVI-I             Nvidia driver : dotclock_min 25.0  (Good performances)     Nouveau : dotclock_min 0.0 (not so good perfomrance)
     GTX 980       DVI-I / HMDI      DVI-I : dotclock_min 0.0        HDMI : dotclock_min 25.0   Nouveau :
-    GTX 1050ti    HDMI              dotclock_min 25.0 (very good performances).
+    GTX 1050ti    HDMI              dotclock_min 25.0 (very good performances)   
     
     Display port (DP) works for all cards but it is only for Super-resolution 240p (no interlace here).
     Turing works poorly only in 240p (tested on GTX 1650 HDMI/DP).

--- a/userdata/system/BUILD_15KHz/Batocera_ALLINONE/BUILD_15KHZ_BATOCERA.sh
+++ b/userdata/system/BUILD_15KHz/Batocera_ALLINONE/BUILD_15KHZ_BATOCERA.sh
@@ -1666,7 +1666,16 @@ if [ ! -f "/userdata/system/batocera.conf.bak" ];then
 	cp /userdata/system/batocera.conf /userdata/system/batocera.conf.bak                                                                                                                                                                  
 fi      
 
-cp /userdata/system/batocera.conf.bak /userdata/system/batocera.conf
+# avoid append on each script launch
+
+LINE_NO=$(sed -n '/## ES Settings, See wiki page on how to center EmulationStation/{=;q;}' /userdata/system/batocera.conf.bak)
+
+if [ -z "$LINE_NO" ]; then 
+	cp /userdata/system/batocera.conf.bak /userdata/system/batocera.conf 
+else 
+	truncate -s 0 batocera.conf
+	sed -n "1,$(( LINE_NO - 1 )) p; $LINE_NO q" /userdata/system/batocera.conf.bak > /userdata/system/batocera.conf
+fi
 
 
 #######################################################################################


### PR DESCRIPTION
This is a Bash script that is designed to modify a configuration file called batocera.conf based on the contents of a backup file called batocera.conf.bak. The script first tries to locate a specific section in the batocera.conf.bak file by searching for a specific comment (## ES Settings, See wiki page on how to center EmulationStation) and determining the line number where this comment appears.

If the comment is found, the script then uses the sed command to extract all the lines in the batocera.conf.bak file that come before the section with the comment, up to the line just before the comment. This extracted content is then written to the batocera.conf file, effectively replacing its contents with the contents of the backup file up to the section with the comment.

If the comment is not found, the script assumes that the batocera.conf file has not been modified before, and simply copies the entire contents of the batocera.conf.bak file to the batocera.conf file.

By using this script, the contents of the batocera.conf file are updated only when necessary, and the original file is not appended with unnecessary data on each script launch.

I realized because I used special ES Settings to center it. After launching the script twice, I saw that the es.customargs used to center ES and other configuration lines were duplicated at the end of batocera.conf. That made ES not to work as it should.
This part of code checks if this can happen and avoid it