### PR TITLE
Update BUILD_15KHZ_BATOCERA.sh

### DIFF
--- a/userdata/system/BUILD_15KHz/Batocera_ALLINONE/BUILD_15KHZ_BATOCERA.sh
+++ b/userdata/system/BUILD_15KHz/Batocera_ALLINONE/BUILD_15KHZ_BATOCERA.sh
@@ -1413,10 +1413,6 @@ if [ ! -f "/usr/bin/emulationstation-standalone.bak" ];then
 	cp /usr/bin/emulationstation-standalone /usr/bin/emulationstation-standalone.bak
 fi
 
-if [ ! -f "/usr/lib/python3.10/site-packages/configgen/generators/mame/mameGenerator.py.bak" ];then
-	cp /usr/lib/python3.10/site-packages/configgen/generators/mame/mameGenerator.py /usr/lib/python3.10/site-packages/configgen/generators/mame/mameGenerator.py.bak
-fi
-
 if [ ! -f "/usr/bin/retroarch.bak" ];then
 	cp /usr/bin/retroarch /usr/bin/retroarch.bak
 fi 


### PR DESCRIPTION
We don't use anymore the copy of mameGenerator.py and the path for 37-dev is dead because the path must be /usr/lib/python3.11/site-packages/configgen/generators/mame/mameGenerator.py