### PR TITLE
Fix shader issue with default shader applied

### DIFF
--- a/userdata/system/BUILD_15KHz/Batocera_ALLINONE/BUILD_15KHZ_BATOCERA.sh
+++ b/userdata/system/BUILD_15KHz/Batocera_ALLINONE/BUILD_15KHZ_BATOCERA.sh
@@ -2013,8 +2013,8 @@ echo "global.retroarch.crt_switch_hires_menu = \"true\""  >> /userdata/system/ba
 echo "###################################################" >> /userdata/system/batocera.conf
 echo "#	DISABLE DEFAULT SHADER, BILINEAR FILTERING & VRR"  >> /userdata/system/batocera.conf
 echo "###################################################" >> /userdata/system/batocera.conf
-echo "global.retroarch.shaderset=none" >> /userdata/system/batocera.conf
-echo "global.retroarch.smooth=0" >> /userdata/system/batocera.conf
+echo "global.shaderset=none" >> /userdata/system/batocera.conf
+echo "global.smooth=0" >> /userdata/system/batocera.conf
 echo "global.retroarch.vrr_runloop_enable=0" >> /userdata/system/batocera.conf
 echo "###################################################" >> /userdata/system/batocera.conf
 echo "#	DISABLE GLOBAL NOTIFICATIONS IN RETROARCH" >> /userdata/system/batocera.conf


### PR DESCRIPTION
Looks like there is an issue in v36 and v37 with the default shader being applied even if we did a global retroarch override. First a taught it had something to do with the GunCon2 shader fix but that is not the case. 

But it still enables the default shader upon boot-up.

`sharp-bilinear-simple.slang`

This fixed the issue